### PR TITLE
Change encoder factory in the UserManager

### DIFF
--- a/src/SimpleUser/UserManager.php
+++ b/src/SimpleUser/UserManager.php
@@ -209,7 +209,7 @@ class UserManager implements UserProviderInterface
      */
     protected function getEncoder(UserInterface $user)
     {
-        return $this->app['security.password_encoder']->getEncoder($user);
+        return $this->app['security.encoder_factory']->getEncoder($user);
     }
 
     /**


### PR DESCRIPTION
I want to fix #4 changing in the `UserManager.php`. In **Silex 2.2**  `getEncoder`method  is set in the `security.encoder_factory service`